### PR TITLE
disable codeCoverage for xcode 9 carthage builds

### DIFF
--- a/JSONWebToken.xcodeproj/xcshareddata/xcschemes/JSONWebToken.xcscheme
+++ b/JSONWebToken.xcodeproj/xcshareddata/xcschemes/JSONWebToken.xcscheme
@@ -41,7 +41,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES"
       enableAddressSanitizer = "YES">
       <Testables>
          <TestableReference


### PR DESCRIPTION
This fixes an issue with iTunes connect upload if the framework is build as a carthage dependency.
With code coverage enabled the framework contains coverage data which leads to a rejection when you upload your app to iTunes Connect.