### PR TITLE
Crash Fix

### DIFF
--- a/JSONWebToken/JSONWebToken.swift
+++ b/JSONWebToken/JSONWebToken.swift
@@ -56,10 +56,10 @@ public struct JSONWebToken {
                 }
             }
             set {
-                if newValue == nil || newValue is NSNull {
-                    jsonPayload.removeValue(forKey: key)
-                } else {
+                if let newValue = newValue {
                     jsonPayload[key] = newValue
+                } else {
+                    jsonPayload.removeValue(forKey: key)
                 }
             }
         }


### PR DESCRIPTION
there is spike in crash recently in this statement so as recommended use safe unwrap instead of newValue == nil.

Crashed: com.apple.main-thread
0  JSONWebToken                   0x10427fe60 $S12JSONWebToken23SignatureValidatorErrorOMa + 656
1  JSONWebToken                   0x104276aa4 specialized _VariantDictionaryBuffer.nativeUpdateValue(_:forKey:) (JSONWebToken.swift)
2  JSONWebToken                   0x104278980 specialized JSONWebToken.Payload.subscript.setter (<compiler-generated>)
3  JSONWebToken                   0x104275134 JSONWebToken.Payload.issuer.setter + 108