### PR TITLE
Fix warnings in Xcode 10.2

### DIFF
--- a/JSONWebToken/SecKeyUtils.swift
+++ b/JSONWebToken/SecKeyUtils.swift
@@ -53,7 +53,7 @@ public extension RSAKey {
         case notBase64Readable
         case badKeyFormat
     }
-    @discardableResult public static func registerOrUpdateKey(_ keyData : Data, tag : String) throws -> RSAKey {
+    @discardableResult static func registerOrUpdateKey(_ keyData : Data, tag : String) throws -> RSAKey {
         let key : SecKey? = try {
             if let existingData = try getKeyData(tag) {
                 let newData = keyData.dataByStrippingX509Header()
@@ -71,11 +71,11 @@ public extension RSAKey {
             throw KeyUtilError.badKeyFormat
         }
     }
-    @discardableResult public static func registerOrUpdateKey(modulus: Data, exponent : Data, tag : String) throws -> RSAKey {
+    @discardableResult static func registerOrUpdateKey(modulus: Data, exponent : Data, tag : String) throws -> RSAKey {
         let combinedData = Data(modulus: modulus, exponent: exponent)
         return try RSAKey.registerOrUpdateKey(combinedData, tag : tag)
     }
-    @discardableResult public static func registerOrUpdatePublicPEMKey(_ keyData : Data, tag : String) throws -> RSAKey {
+    @discardableResult static func registerOrUpdatePublicPEMKey(_ keyData : Data, tag : String) throws -> RSAKey {
         guard let stringValue = String(data: keyData, encoding: String.Encoding.utf8) else {
             throw KeyUtilError.notStringReadable
         }


### PR DESCRIPTION
Hi @antoinepalazzolo and @g-bourachot , we use your SDK in a framework we develop, and one of our clients has a zero-warnings policy in 3rd party SDKs. This PR fixes warnings that appear in Xcode 10.2 and should have no risk associated with it. I also verified that building in Xcode 10.1 still works.

This was the warning in all three cases:
`'public' modifier is redundant for static method declared in a public extension`

Thanks!